### PR TITLE
Improve application configuration docs

### DIFF
--- a/docs/en/framework/api-development/standard-apis/configuration.md
+++ b/docs/en/framework/api-development/standard-apis/configuration.md
@@ -59,3 +59,11 @@ namespace Acme.BookStore.Web
 * You can inject services and perform any logic needed to extend the endpoint as you wish.
 
 > Application configuration contributors are automatically discovered by the ABP and executed as a part of the application configuration initialization process.
+
+### Service Overview
+
+The `AbpApplicationConfigurationAppService` class is responsible for gathering
+all the sections returned from the endpoint. It builds authentication, feature
+and localization data by calling helper methods like `GetAuthConfigAsync` or
+`GetLocalizationConfigAsync`. Derive from this service and override these
+methods if you need to customize the response.

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ApplicationConfigurations/AbpApplicationConfigurationAppService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ApplicationConfigurations/AbpApplicationConfigurationAppService.cs
@@ -24,6 +24,9 @@ using Volo.Abp.Users;
 
 namespace Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations;
 
+/// <summary>
+/// Gathers runtime configuration information of the application for the client side.
+/// </summary>
 public class AbpApplicationConfigurationAppService : ApplicationService, IAbpApplicationConfigurationAppService
 {
     private readonly AbpLocalizationOptions _localizationOptions;
@@ -44,6 +47,9 @@ public class AbpApplicationConfigurationAppService : ApplicationService, IAbpApp
     private readonly ICachedObjectExtensionsDtoService _cachedObjectExtensionsDtoService;
     private readonly AbpApplicationConfigurationOptions _options;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AbpApplicationConfigurationAppService"/> class.
+    /// </summary>
     public AbpApplicationConfigurationAppService(
         IOptions<AbpLocalizationOptions> localizationOptions,
         IOptions<AbpMultiTenancyOptions> multiTenancyOptions,
@@ -82,6 +88,10 @@ public class AbpApplicationConfigurationAppService : ApplicationService, IAbpApp
         _multiTenancyOptions = multiTenancyOptions.Value;
     }
 
+    /// <summary>
+    /// Returns configuration information used by the client side of the application.
+    /// </summary>
+    /// <param name="options">Request options to control the content of the response.</param>
     public virtual async Task<ApplicationConfigurationDto> GetAsync(ApplicationConfigurationRequestOptions options)
     {
         //TODO: Optimize & cache..?
@@ -121,6 +131,9 @@ public class AbpApplicationConfigurationAppService : ApplicationService, IAbpApp
         return result;
     }
 
+    /// <summary>
+    /// Creates a <see cref="CurrentTenantDto"/> object for the current tenant.
+    /// </summary>
     protected virtual CurrentTenantDto GetCurrentTenant()
     {
         return new CurrentTenantDto()
@@ -131,6 +144,9 @@ public class AbpApplicationConfigurationAppService : ApplicationService, IAbpApp
         };
     }
 
+    /// <summary>
+    /// Gets basic multi-tenancy information of the application.
+    /// </summary>
     protected virtual MultiTenancyInfoDto GetMultiTenancy()
     {
         return new MultiTenancyInfoDto
@@ -139,6 +155,9 @@ public class AbpApplicationConfigurationAppService : ApplicationService, IAbpApp
         };
     }
 
+    /// <summary>
+    /// Creates a <see cref="CurrentUserDto"/> describing the current user.
+    /// </summary>
     protected virtual CurrentUserDto GetCurrentUser()
     {
         return new CurrentUserDto
@@ -162,6 +181,9 @@ public class AbpApplicationConfigurationAppService : ApplicationService, IAbpApp
         };
     }
 
+    /// <summary>
+    /// Builds the authentication configuration part of the application configuration.
+    /// </summary>
     protected virtual async Task<ApplicationAuthConfigurationDto> GetAuthConfigAsync()
     {
         var authConfig = new ApplicationAuthConfigurationDto();
@@ -203,6 +225,9 @@ public class AbpApplicationConfigurationAppService : ApplicationService, IAbpApp
         return authConfig;
     }
 
+    /// <summary>
+    /// Gets localization information including languages and resources.
+    /// </summary>
     protected virtual async Task<ApplicationLocalizationConfigurationDto> GetLocalizationConfigAsync(
         ApplicationConfigurationRequestOptions options)
     {
@@ -261,6 +286,9 @@ public class AbpApplicationConfigurationAppService : ApplicationService, IAbpApp
         return CurrentCultureDto.Create();
     }
 
+    /// <summary>
+    /// Retrieves application setting values visible to clients.
+    /// </summary>
     private async Task<ApplicationSettingConfigurationDto> GetSettingConfigAsync()
     {
         var result = new ApplicationSettingConfigurationDto
@@ -280,6 +308,9 @@ public class AbpApplicationConfigurationAppService : ApplicationService, IAbpApp
         return result;
     }
 
+    /// <summary>
+    /// Collects feature values that are visible to clients.
+    /// </summary>
     protected virtual async Task<ApplicationFeatureConfigurationDto> GetFeaturesConfigAsync()
     {
         var result = new ApplicationFeatureConfigurationDto();
@@ -297,6 +328,9 @@ public class AbpApplicationConfigurationAppService : ApplicationService, IAbpApp
         return result;
     }
 
+    /// <summary>
+    /// Returns the list of globally enabled features.
+    /// </summary>
     protected virtual Task<ApplicationGlobalFeatureConfigurationDto> GetGlobalFeaturesConfigAsync()
     {
         var result = new ApplicationGlobalFeatureConfigurationDto();
@@ -309,6 +343,9 @@ public class AbpApplicationConfigurationAppService : ApplicationService, IAbpApp
         return Task.FromResult(result);
     }
 
+    /// <summary>
+    /// Gets time zone information of the current user and application clock.
+    /// </summary>
     protected virtual async Task<TimingDto> GetTimingConfigAsync()
     {
         var timeZone = await _settingProvider.GetOrNullAsync(TimingSettingNames.TimeZone);
@@ -354,6 +391,9 @@ public class AbpApplicationConfigurationAppService : ApplicationService, IAbpApp
         };
     }
 
+    /// <summary>
+    /// Gets the clock configuration of the application.
+    /// </summary>
     protected virtual ClockDto GetClockConfig()
     {
         return new ClockDto


### PR DESCRIPTION
## Summary
- document `AbpApplicationConfigurationAppService` in standard API docs
- add XML documentation comments to `AbpApplicationConfigurationAppService`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852eb220b588332a0ebd5c6025c6c34